### PR TITLE
feat: HMAC signing and support of GasFree

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -89,6 +89,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
 
 [[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
 name = "base64ct"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -856,7 +862,7 @@ version = "8.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc9051c17f81bae79440afa041b3a278e1de71bfb96d32454b477fd4703ccb6f"
 dependencies = [
- "base64",
+ "base64 0.13.0",
  "pem",
  "ring",
  "serde",
@@ -1054,10 +1060,12 @@ name = "main"
 version = "0.1.0"
 dependencies = [
  "async-trait",
+ "base64 0.22.1",
  "bytes",
  "ethereum-types",
  "futures-util",
  "hex",
+ "hmac",
  "hyper",
  "hyper-tls",
  "jemallocator",
@@ -1069,6 +1077,7 @@ dependencies = [
  "redis",
  "serde",
  "serde_json",
+ "sha2",
  "sha3",
  "simple_logger",
  "timed-map",
@@ -1307,7 +1316,7 @@ version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e9a3b09a20e374558580a4914d3b7d89bd61b954a5a5e1dcbea98753addb1947"
 dependencies = [
- "base64",
+ "base64 0.13.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,9 +10,11 @@ path = "src/main.rs"
 
 [dependencies]
 async-trait = "0.1.53"
+base64 = "0.22"
 bytes = "1.1.0"
 ethereum-types = { version = "0.4", default-features = false, features = ["std", "serialize"] }
 futures-util = "0.3.21"
+hmac = "0.12"
 hyper = { version = "0.14.18", default-features = false, features = ["server", "http1", "http2", "tcp", "client"] }
 hyper-tls = "0.5.0"
 jsonwebtoken = "8.1.0"
@@ -22,6 +24,7 @@ url = { version = "2.2.2", features = ["serde"] }
 redis = { version = "0.21.5", default-features = false, features = ["tokio-comp"] }
 serde = "1.0.137"
 serde_json = { version = "1.0.81", features = ["preserve_order", "raw_value"] }
+sha2 = "0.10"
 sha3 = "0.9"
 simple_logger = "2.1.0"
 timed-map = { version = "1.1", features = ["rustc-hash"] }

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Create the configuration file for app runtime.
     {
       "inbound_route": "/dev",
       "outbound_route": "http://localhost:8000",
-      "proxy_type": "quicknode", # available types are: "quicknode", "moralis", "block_pi"
+      "proxy_type": "quicknode", # available types are: "quicknode", "moralis", "block_pi", "gas_free"
       "authorized": false,
       "allowed_rpc_methods": [
         "eth_blockNumber",
@@ -44,6 +44,24 @@ Create the configuration file for app runtime.
     "rp_60_min": 575
   },
   "peer_healthcheck_caching_secs": 10
+}
+```
+
+GasFree routes keep the GasFree API credentials on the proxy server and forward both GET and POST requests to the upstream path after the inbound prefix is stripped:
+
+```json
+{
+  "inbound_route": "/gasfree",
+  "outbound_route": "https://open.gasfree.io",
+  "proxy_type": {
+    "gas_free": {
+      "api_key": "your-gasfree-api-key",
+      "api_secret": "your-gasfree-api-secret"
+    }
+  },
+  "authorized": false,
+  "allowed_rpc_methods": [],
+  "rate_limiter": null
 }
 ```
 

--- a/assets/.config_test
+++ b/assets/.config_test
@@ -52,6 +52,19 @@
       }
     },
     {
+      "inbound_route": "/gasfree",
+      "outbound_route": "https://open.gasfree.io",
+      "proxy_type": {
+        "gas_free": {
+          "api_key": "test-gasfree-api-key",
+          "api_secret": "test-gasfree-api-secret"
+        }
+      },
+      "authorized": false,
+      "allowed_rpc_methods": [],
+      "rate_limiter": null
+    },
+    {
       "inbound_route": "/",
       "outbound_route": "https://adex.io",
       "proxy_type": "moralis",

--- a/src/ctx.rs
+++ b/src/ctx.rs
@@ -194,6 +194,17 @@ pub(crate) fn get_app_config_test_instance() -> AppConfig {
                 }),
             },
             ProxyRoute {
+                inbound_route: String::from("/gasfree"),
+                outbound_route: String::from("https://open.gasfree.io"),
+                proxy_type: ProxyType::GasFree {
+                    api_key: String::from("test-gasfree-api-key"),
+                    api_secret: String::from("test-gasfree-api-secret"),
+                },
+                authorized: false,
+                allowed_rpc_methods: Vec::default(),
+                rate_limiter: None,
+            },
+            ProxyRoute {
                 inbound_route: String::from("/"),
                 outbound_route: String::from("https://adex.io"),
                 proxy_type: ProxyType::Moralis,
@@ -273,6 +284,19 @@ fn test_app_config_serialzation_and_deserialization() {
                     "rp_30_min": 1000,
                     "rp_60_min": 2000
                 }
+            },
+            {
+                "inbound_route": "/gasfree",
+                "outbound_route": "https://open.gasfree.io",
+                "proxy_type": {
+                    "gas_free": {
+                        "api_key": "test-gasfree-api-key",
+                        "api_secret": "test-gasfree-api-secret"
+                    }
+                },
+                "authorized": false,
+                "allowed_rpc_methods": [],
+                "rate_limiter": null
             },
             {
                 "inbound_route": "/",

--- a/src/proxy/http/gasfree.rs
+++ b/src/proxy/http/gasfree.rs
@@ -1,0 +1,162 @@
+use crate::ctx::ProxyRoute;
+use crate::logger::tracked_log;
+use crate::proxy::http::get::modify_request_uri;
+use crate::proxy::{
+    remove_hop_by_hop_headers, response_by_status, ProxyType, APPLICATION_JSON, X_FORWARDED_FOR,
+};
+use crate::GenericResult;
+use base64::engine::general_purpose::STANDARD as BASE64_STANDARD;
+use base64::Engine;
+use hmac::{Hmac, Mac};
+use hyper::header::{HeaderName, HeaderValue};
+use hyper::{header, Body, Request, Response, StatusCode};
+use hyper_tls::HttpsConnector;
+use proxy_signature::ProxySign;
+use sha2::Sha256;
+use std::net::SocketAddr;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+const GASFREE_TIMESTAMP_HEADER: &str = "timestamp";
+
+type HmacSha256 = Hmac<Sha256>;
+
+pub(crate) async fn proxy(
+    mut req: Request<Body>,
+    remote_addr: &SocketAddr,
+    signed_message: ProxySign,
+    x_forwarded_for: HeaderValue,
+    proxy_route: &ProxyRoute,
+) -> GenericResult<Response<Body>> {
+    let (api_key, api_secret) = match &proxy_route.proxy_type {
+        ProxyType::GasFree {
+            api_key,
+            api_secret,
+        } => (api_key.as_str(), api_secret.as_str()),
+        _ => {
+            tracked_log(
+                log::Level::Error,
+                remote_addr.ip(),
+                signed_message.address,
+                req.uri(),
+                "GasFree handler received a non-GasFree route, returning 500.",
+            );
+            return response_by_status(StatusCode::INTERNAL_SERVER_ERROR);
+        }
+    };
+
+    let original_req_uri = req.uri().clone();
+
+    if let Err(e) = modify_request_uri(&mut req, proxy_route) {
+        tracked_log(
+            log::Level::Error,
+            remote_addr.ip(),
+            signed_message.address,
+            original_req_uri,
+            format!("Error modifying request base Uri: {}, returning 500.", e),
+        );
+        return response_by_status(StatusCode::INTERNAL_SERVER_ERROR);
+    }
+
+    if let Err(e) = insert_gasfree_auth_headers(&mut req, api_key, api_secret) {
+        tracked_log(
+            log::Level::Error,
+            remote_addr.ip(),
+            signed_message.address,
+            req.uri(),
+            format!(
+                "Error inserting GasFree auth headers: {}, returning 500.",
+                e
+            ),
+        );
+        return response_by_status(StatusCode::INTERNAL_SERVER_ERROR);
+    }
+
+    remove_hop_by_hop_headers(&mut req, &[])?;
+
+    req.headers_mut()
+        .insert(HeaderName::from_static(X_FORWARDED_FOR), x_forwarded_for);
+    req.headers_mut()
+        .insert(header::ACCEPT, APPLICATION_JSON.parse()?);
+    req.headers_mut()
+        .insert(header::CONTENT_TYPE, APPLICATION_JSON.parse()?);
+
+    let https = HttpsConnector::new();
+    let client = hyper::Client::builder().build(https);
+
+    let target_uri = req.uri().clone();
+    let res = match client.request(req).await {
+        Ok(t) => t,
+        Err(e) => {
+            tracked_log(
+                log::Level::Warn,
+                remote_addr.ip(),
+                signed_message.address,
+                original_req_uri,
+                format!("Couldn't reach {}: {}. Returning 503.", target_uri, e),
+            );
+            return response_by_status(StatusCode::SERVICE_UNAVAILABLE);
+        }
+    };
+
+    Ok(res)
+}
+
+pub(crate) fn build_hmac_authorization(
+    api_key: &str,
+    api_secret: &str,
+    method: &str,
+    request_path: &str,
+    timestamp: u64,
+) -> String {
+    let string_to_sign = format!("{method}{request_path}{timestamp}");
+    let mut mac = HmacSha256::new_from_slice(api_secret.as_bytes())
+        .expect("HMAC-SHA256 accepts arbitrary-length keys");
+    mac.update(string_to_sign.as_bytes());
+    let signature = BASE64_STANDARD.encode(mac.finalize().into_bytes());
+    format!("ApiKey {api_key}:{signature}")
+}
+
+fn insert_gasfree_auth_headers(
+    req: &mut Request<Body>,
+    api_key: &str,
+    api_secret: &str,
+) -> GenericResult<()> {
+    let timestamp = SystemTime::now().duration_since(UNIX_EPOCH)?.as_secs();
+    let authorization = build_hmac_authorization(
+        api_key,
+        api_secret,
+        req.method().as_str(),
+        req.uri().path(),
+        timestamp,
+    );
+
+    req.headers_mut().insert(
+        HeaderName::from_static(GASFREE_TIMESTAMP_HEADER),
+        timestamp.to_string().parse()?,
+    );
+    req.headers_mut()
+        .insert(header::AUTHORIZATION, authorization.parse()?);
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_build_hmac_authorization_known_vector() {
+        let authorization = build_hmac_authorization(
+            "test-key",
+            "test-secret",
+            "GET",
+            "/nile/api/v1/config/token/all",
+            1_731_912_286,
+        );
+
+        assert_eq!(
+            authorization,
+            "ApiKey test-key:sYfwaLSnifcL/MTLFDmfORdCVceFLckEPL1mMKEjTHQ="
+        );
+    }
+}

--- a/src/proxy/http/mod.rs
+++ b/src/proxy/http/mod.rs
@@ -14,6 +14,7 @@ use crate::{
     rate_limiter::RateLimitOperations,
 };
 
+pub(crate) mod gasfree;
 pub(crate) mod get;
 pub(crate) mod post;
 

--- a/src/proxy/mod.rs
+++ b/src/proxy/mod.rs
@@ -31,6 +31,7 @@ pub(crate) enum ProxyType {
     Quicknode,
     Moralis,
     BlockPi,
+    GasFree { api_key: String, api_secret: String },
 }
 
 /// Represents the types of payloads that can be processed by the proxy, with each variant tailored to a specific proxy type.
@@ -49,6 +50,8 @@ pub(crate) enum PayloadData {
         payload: RpcPayload,
         proxy_sign: ProxySign,
     },
+    /// GasFree feature requires only Signed Message in X-Auth-Payload header; body is forwarded intact.
+    GasFree(ProxySign),
 }
 
 impl PayloadData {
@@ -58,6 +61,7 @@ impl PayloadData {
             PayloadData::Quicknode { proxy_sign, .. } => proxy_sign,
             PayloadData::Moralis(proxy_sign) => proxy_sign,
             PayloadData::BlockPi { proxy_sign, .. } => proxy_sign,
+            PayloadData::GasFree(proxy_sign) => proxy_sign,
         }
     }
 }
@@ -89,6 +93,10 @@ pub(crate) async fn generate_payload_from_req(
                 proxy_sign,
             };
             Ok((req, payload_data))
+        }
+        ProxyType::GasFree { .. } => {
+            let (req, proxy_sign) = parse_auth_header(req).await?;
+            Ok((req, PayloadData::GasFree(proxy_sign)))
         }
     }
 }
@@ -142,6 +150,9 @@ pub(crate) async fn proxy(
                 proxy_route,
             )
             .await
+        }
+        PayloadData::GasFree(proxy_sign) => {
+            http::gasfree::proxy(req, remote_addr, proxy_sign, x_forwarded_for, proxy_route).await
         }
     }
 }
@@ -273,6 +284,16 @@ pub(crate) async fn insert_jwt_to_http_header(
     Ok(())
 }
 
+fn resolve_proxy_route<'a>(cfg: &'a AppConfig, req: &mut Request<Body>) -> Option<&'a ProxyRoute> {
+    match req.method() {
+        &Method::GET => cfg.get_proxy_route_by_uri(req.uri_mut()),
+        _ => {
+            let by_inbound = cfg.get_proxy_route_by_inbound(req.uri().path());
+            by_inbound.or_else(|| cfg.get_proxy_route_by_uri(req.uri_mut()))
+        }
+    }
+}
+
 pub(crate) async fn http_handler(
     cfg: &AppConfig,
     mut req: Request<Body>,
@@ -303,34 +324,18 @@ pub(crate) async fn http_handler(
         return handle_preflight();
     }
 
-    let proxy_route = match req.method() {
-        &Method::GET => match cfg.get_proxy_route_by_uri(req.uri_mut()) {
-            Some(proxy_route) => proxy_route,
-            None => {
-                tracked_log(
-                    log::Level::Warn,
-                    remote_addr.ip(),
-                    "**not-available**",
-                    req_uri,
-                    "Proxy route not found for GET request, returning 404.",
-                );
-
-                return response_by_status(StatusCode::NOT_FOUND);
-            }
-        },
-        _ => match cfg.get_proxy_route_by_inbound(req.uri().path()) {
-            Some(proxy_route) => proxy_route,
-            None => {
-                tracked_log(
-                    log::Level::Warn,
-                    remote_addr.ip(),
-                    "**not-available**",
-                    req_uri,
-                    "Proxy route not found for non-GET request, returning 404.",
-                );
-                return response_by_status(StatusCode::NOT_FOUND);
-            }
-        },
+    let Some(proxy_route) = resolve_proxy_route(cfg, &mut req) else {
+        tracked_log(
+            log::Level::Warn,
+            remote_addr.ip(),
+            "**not-available**",
+            req_uri,
+            format!(
+                "Proxy route not found for {} request, returning 404.",
+                req.method()
+            ),
+        );
+        return response_by_status(StatusCode::NOT_FOUND);
     };
 
     let (req, payload) = match generate_payload_from_req(req, &proxy_route.proxy_type).await {


### PR DESCRIPTION
Adds a `gas_free` `ProxyType` so KDF clients can use the TRON GasFree service (`open.gasfree.io`) without ever holding the GasFree API keys.

Example route config (`api_key`/`api_secret` stay server-side, mainnet and Nile are separate routes since they have separate hosts and keys):

```json
{
  "inbound_route": "/gasfree",
  "outbound_route": "https://open.gasfree.io",
  "proxy_type": { "gas_free": { "api_key": "<api key>", "api_secret": "<api secret>" } },
  "authorized": false,
  "allowed_rpc_methods": [],
  "rate_limiter": null
}
```
